### PR TITLE
fix(): 解决am-checkbox在小程序插件中样式展示异常的问题

### DIFF
--- a/src/am-checkbox/index.axml
+++ b/src/am-checkbox/index.axml
@@ -7,5 +7,5 @@
     onChange="onChange"
     id="{{id}}"
     />
-  <view class="am-checkbox-synthetic"></view>
+  <view class="{{`am-checkbox-synthetic  ${_checked ? 'am-checkbox-checked' : ''} ${disabled ? 'am-checkbox-disabled' : ''}`}}"></view>
 </view>

--- a/src/am-checkbox/index.less
+++ b/src/am-checkbox/index.less
@@ -46,13 +46,13 @@
   border: var(--am-checkbox-border-width, @border-width-standard) solid var(--am-checkbox-border-color, @color-fill-grey-base);
 }
 
-.am-checkbox-value.a-checkbox-checked + .am-checkbox-synthetic::before {
+.am-checkbox-synthetic.am-checkbox-checked::before {
   .amFormat(background-color, am-checkbox-background, @color-fill-primary);
   .amFormat(border-color, am-checkbox-background, @color-fill-primary);
   border-width: 0;
 }
 
-.am-checkbox-value.a-checkbox-checked + .am-checkbox-synthetic::after {
+.am-checkbox-synthetic.am-checkbox-checked::after {
   position: absolute;
   display: block;
   z-index: 2;
@@ -67,13 +67,13 @@
   background-repeat: no-repeat;
 }
 
-.am-checkbox-value.a-checkbox-disabled + .am-checkbox-synthetic::before {
+.am-checkbox-synthetic.am-checkbox-disabled::before {
   border: @border-width-standard solid @color-fill-grey-base;
   border: var(--am-checkbox-border-width, @border-width-standard) solid var(--am-checkbox-border-color, @color-fill-grey-base);
   .amFormat(background-color, am-checkbox-disabled-background, @color-fill-grey-light);
 }
 
-.am-checkbox-value.a-checkbox-checked.a-checkbox-disabled + .am-checkbox-synthetic::after {
+.am-checkbox-synthetic.am-checkbox-checked.am-checkbox-disabled::after {
   position: absolute;
   display: block;
   z-index: 2;

--- a/src/am-checkbox/index.ts
+++ b/src/am-checkbox/index.ts
@@ -9,8 +9,23 @@ Component({
     color: '',
     id: '',
   },
+  data: {
+    // 组件内维护的chackbox勾选状态
+    _checked: false,
+  },
+  onInit() {
+    const { checked } = this.props;
+    this.setData({
+      _checked: checked,
+    });
+  },
   methods: {
     onChange(e) {
+      const { detail = {} } = e;
+      const { value } = detail;
+      this.setData({
+        _checked: value,
+      });
       const event = fmtEvent(this.props, e);
       this.props.onChange(event);
     },


### PR DESCRIPTION
修改am-checkbox组件，使其不依赖于基础组件的类名a-checkbox-checked，从而解决小程序插件内使用am-checkbox组件时类名加前缀引起的样式展示异常的问题。