### PR TITLE
fix: 修改content不在最左侧问题

### DIFF
--- a/src/popup/index.less
+++ b/src/popup/index.less
@@ -1,6 +1,7 @@
 .am-popup {
   &-content {
     position: fixed;
+    left: 0;
   }
 
   &-mask {


### PR DESCRIPTION
当 `<popup />` 没有在最外层使用，content 可能会没有居左，需要手动设置 left: 0 确保 content 是 fixed 最左侧

点这个链接查看问题：https://herbox-embed.alipay.com/p/herbox-cli-test/popup


First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

Extra checklist:

**if** *isNewFeature* **:**

  * [ ] Update API docs for the component.
  * [ ] Update/Add demo to demonstrate new feature.
  * [ ] Update TypeScript definition for the component.
