### PR TITLE
fix: 选择器className拼接错误

### DIFF
--- a/src/tabs/index.ts
+++ b/src/tabs/index.ts
@@ -206,7 +206,7 @@ Component({
       let boxWidth = 0;
       let elWidth = 0;
       let elLeft = 0;
-      const className = `am-tabs-bar-tab ${!this.props.hasSubTitle && this.props.capsule ? 'am-tabs-bar-tab-capsule' : ''} ${this.props.hasSubTitle ? 'am-tabs-bar-tab__hasSubTitle' : ''} ${this.props.tabBarCls}`;
+      const className = `am-tabs-bar-tab${!this.props.hasSubTitle && this.props.capsule ? '.am-tabs-bar-tab-capsule' : ''}${this.props.hasSubTitle ? '.am-tabs-bar-tab__hasSubTitle' : ''}${this.props.tabBarCls ? ('.' + this.props.tabBarCls) : ''}`;
 
       my.createSelectorQuery().selectAll(`.${className}`).boundingClientRect().exec((ret) => {
         if (ret && ret[0]) {


### PR DESCRIPTION
#77 
这个issue中描述的bug的原因是selectorQuery选择器的className拼接错误。
比如说有a, b两个class，那么在选择器中使用，应该是`'.a.b'`，而不是`'.a b'`