### PR TITLE
fix: 电梯模式页面回滚时的bug

### DIFF
--- a/demo/pages/tabs/elevator/elevator.axml
+++ b/demo/pages/tabs/elevator/elevator.axml
@@ -4,6 +4,7 @@
 </view>
 <view style="padding: 12px;">
   <tabs
+    ref="saveRef"
     tabs="{{tabs}}"
     tabsName="activeTab"
     onTabClick="handleTabClick"

--- a/demo/pages/tabs/elevator/elevator.js
+++ b/demo/pages/tabs/elevator/elevator.js
@@ -32,7 +32,7 @@ Page({
         subTitle: '描述',
       },
     ],
-    activeTab: 5,
+    activeTab: 0,
     contentHeight: 200,
   },
   changeHeight() {
@@ -40,7 +40,17 @@ Page({
       contentHeight: this.data.contentHeight + 200,
     });
   },
+  saveRef(ref) {
+    this.ref = ref;
+  },
   onLoad() {
+    setTimeout(() => {
+      this.setData({
+        activeTab: 5,
+      });
+      // 需要手动调用scrollTo方法使tab和相应页面保持一致
+      this.ref.scrollTo(5);
+    }, 1000);
   },
   handleTabClick({ index, tabsName }) {
     this.setData({

--- a/src/tabs/index.ts
+++ b/src/tabs/index.ts
@@ -196,11 +196,6 @@ Component({
           tabViewNum: currentActiveTab,
           prevTabViewNum: prevData.tabViewNum,
         });
-
-        my.pageScrollTo({
-          scrollTop: Math.ceil(this.data.floorNumber[currentActiveTab]),
-          duration: 1,
-        });
       }
     } else if (currentActiveTab !== prevProps.activeTab) {
       let boxWidth = 0;
@@ -268,6 +263,13 @@ Component({
     }
   },
   methods: {
+    // 此方法供用户以ref方式调用
+    scrollTo(activeTab: number) {
+      my.pageScrollTo({
+        scrollTop: Math.ceil(this.data.floorNumber[activeTab]),
+        duration: 1,
+      });
+    },
     setWindowWidth() {
       my.getSystemInfo({
         success: (res) => {


### PR DESCRIPTION
#79 
issue中提到的问题，原因是：
在滚动中，重设了activeTab(elevator.js)。组件中，didUpdate时发现activeTab变了，然后调用my.pageScrollTo，将页面滚动至该activeTab的起始点，再次触发elevator.js中的滚动监听事件，这样一系列的变化造成了bug。

我的解决方案：
在didUpdate中，不再调用my.pageScrollTo。但当使用者想改变activeTab，多加一个步骤——手动滚动页面。
这样做的原因是，在didUpdate发现activeTab改变时，无法区分这是手动用代码改变的（直接用setData改变activeTab），还是在pageScroll时改变的。因此只能统一不调用my.pageScrollTo。